### PR TITLE
keycode has an uppercase letter in it

### DIFF
--- a/global_hotkeys/keycodes.py
+++ b/global_hotkeys/keycodes.py
@@ -122,7 +122,7 @@ vk_key_names = {
 	'browser_favorites':0xAB,
 	'browser_start_and_home':0xAC,
 	'volume_mute':0xAD,
-	'volume_Down':0xAE,
+	'volume_down':0xAE,
 	'volume_up':0xAF,
 	'next_track':0xB0,
 	'previous_track':0xB1,


### PR DESCRIPTION
this way the script is not finding it with "volume_Down".lower() as an index