### PR TITLE
Fix press_callback != None with callback_params == None problem

### DIFF
--- a/global_hotkeys/hotkey_checker.py
+++ b/global_hotkeys/hotkey_checker.py
@@ -236,7 +236,7 @@ class HotkeyChecker():
                             if callback_params != None:
                                 press_callback(callback_params)
                             else:
-                                press_callback(callback_params)
+                                press_callback()
                 else:
                     this_is_the_last_chord = key_state_id == len(hotkey) - 1
                     #self.hotkey_actions[id][2] = False


### PR DESCRIPTION
When press_callback != None, callback_params will always be passed to press_callback() even if callback_params == None. This PR tries to fix that.